### PR TITLE
Fix Android doc test path resolution

### DIFF
--- a/Tests/SyntaxDocTests/DocumentationExampleTests.swift
+++ b/Tests/SyntaxDocTests/DocumentationExampleTests.swift
@@ -42,7 +42,7 @@ internal struct DocumentationExampleTests {
   @Test("Quick Start Guide examples work correctly")
   internal func validateQuickStartGuideExamples() throws {
     let quickStartFile = try Settings.resolveFilePath(
-      "Sources/SyntaxKit/Documentation.docc/Tutorials/Quick-Start-Guide.md"
+      "Documentation.docc/Tutorials/Quick-Start-Guide.md"
     )
     let results = try testHarness.validateFile(at: quickStartFile)
 
@@ -57,7 +57,7 @@ internal struct DocumentationExampleTests {
   @Test("Creating Macros tutorial examples work correctly")
   internal func validateMacroTutorialExamples() throws {
     let macroTutorialFile = try Settings.resolveFilePath(
-      "Sources/SyntaxKit/Documentation.docc/Tutorials/Creating-Macros-with-SyntaxKit.md"
+      "Documentation.docc/Tutorials/Creating-Macros-with-SyntaxKit.md"
     )
     let results = try testHarness.validateFile(at: macroTutorialFile)
 

--- a/Tests/SyntaxDocTests/Settings.swift
+++ b/Tests/SyntaxDocTests/Settings.swift
@@ -81,7 +81,12 @@ internal enum Settings {
         return .init(fileURLWithPath: filePath)
       }
     } else {
-      return Self.projectRoot.appendingPathComponent(filePath)
+      #if os(Android)
+      let resolvedPath = filePath
+      #else
+      let resolvedPath = "Sources/SyntaxKit/" + filePath
+      #endif
+      return Self.projectRoot.appendingPathComponent(resolvedPath)
     }
   }
 }


### PR DESCRIPTION
## Summary
- `resolveFilePath` in `Settings.swift` now prepends `Sources/SyntaxKit/` on non-Android platforms
- Test methods in `DocumentationExampleTests.swift` use the short-form path (`Documentation.docc/Tutorials/...`) without the prefix
- Fixes the two failing "Documentation Code Examples" tests on all Android CI jobs

## Root cause
On Android, `Documentation.docc` is copied flat to the test working directory — there's no `Sources/SyntaxKit/` subdirectory. The two specific test methods hardcoded the full path, causing a "file doesn't exist" error. `Settings.docPaths` already handled this correctly; `resolveFilePath` now does too.

## Test plan
- [ ] Verify Android CI passes (all 3 Android jobs)
- [ ] Verify macOS/Linux CI still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/brightdigit/SyntaxKit/130)
<!-- GitContextEnd -->