### PR TITLE
Fix Windows CI: update swift-docc-plugin to 1.4.6

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "3a9631966aed0489b1d0415c39c345f4083602bf6a2ddfdc7954cd286093542f",
+  "originHash" : "482d43aff5bb5c075d237e0ea17c12ee2c043b2642e459260752aa1848a20593",
   "pins" : [
     {
       "identity" : "swift-docc-plugin",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-docc-plugin",
       "state" : {
-        "revision" : "3e4f133a77e644a5812911a0513aeb7288b07d06",
-        "version" : "1.4.5"
+        "revision" : "e977f65879f82b375a044c8837597f690c067da6",
+        "version" : "1.4.6"
       }
     },
     {


### PR DESCRIPTION
## Summary

- Updates `swift-docc-plugin` from `1.4.5` → `1.4.6` in `Package.resolved`

## Problem

Windows CI (`windows-2022` and `windows-2025`) was failing with:

```
error: cannot find 'Lock' in scope
error: cannot find type 'SnippetExtractor' in scope
error: cannot find type 'ParsedSymbolGraphArguments' in scope
```

The root cause: `swift-docc-plugin` uses a `Symbolic Links/` directory to share source files across plugin targets. On Windows, without proper `.gitattributes`, git checks these symlinks out as plain text files (containing just the path string). The Swift compiler then tries to compile these empty stubs, producing missing-type errors.

## Fix

`swift-docc-plugin` 1.4.6 release notes: _"Add .gitattributes for symlinks on Windows."_ — this ensures git resolves symlinks to real source files on Windows checkouts.

`Package.swift` already declares `from: "1.4.0"`, so only `Package.resolved` needed updating.

## Test plan

- [ ] `Build on Windows (windows-2022)` passes
- [ ] `Build on Windows (windows-2025)` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- GitContextStart -->
- - -
Perform an AI-assisted review on [<img src="https://codepeer.com/logo/CodePeerButton.svg" height="32" align="absmiddle" alt="CodePeer.com"/>](https://codepeer.com/app/prs/github/brightdigit/SyntaxKit/131)
<!-- GitContextEnd -->