### PR TITLE
Implement AnalyzerConfiguration and AnalyzerError (#110)

### DIFF
--- a/Sources/AiSTKit/AnalyzerConfiguration.swift
+++ b/Sources/AiSTKit/AnalyzerConfiguration.swift
@@ -31,8 +31,10 @@
 /// subcommand from parsed command-line arguments and handed to
 /// `SyntaxKitAnalyzer`.
 public struct AnalyzerConfiguration: Sendable {
-  /// Folder containing `dsl.swift` and `expected.swift`.
-  public let inputFolderPath: String
+  /// Path to the DSL input file (`dsl.swift`).
+  public let dslFilePath: String
+  /// Path to the expected Swift output file (`expected.swift`).
+  public let expectedFilePath: String
   /// Path to the existing SyntaxKit library sources.
   public let syntaxKitPath: String
   /// Where to write the updated library.
@@ -47,21 +49,24 @@ public struct AnalyzerConfiguration: Sendable {
   /// Creates an analyzer configuration.
   ///
   /// - Parameters:
-  ///   - inputFolderPath: Folder containing `dsl.swift` and `expected.swift`.
+  ///   - dslFilePath: Path to the DSL input file (`dsl.swift`).
+  ///   - expectedFilePath: Path to the expected Swift output file (`expected.swift`).
   ///   - syntaxKitPath: Path to the existing SyntaxKit library sources.
   ///   - outputFolderPath: Where to write the updated library.
   ///   - apiKey: Claude API key.
   ///   - model: Claude model identifier.
   ///   - verbose: Enables verbose progress output.
   public init(
-    inputFolderPath: String,
+    dslFilePath: String,
+    expectedFilePath: String,
     syntaxKitPath: String,
     outputFolderPath: String,
     apiKey: String,
     model: String,
     verbose: Bool
   ) {
-    self.inputFolderPath = inputFolderPath
+    self.dslFilePath = dslFilePath
+    self.expectedFilePath = expectedFilePath
     self.syntaxKitPath = syntaxKitPath
     self.outputFolderPath = outputFolderPath
     self.apiKey = apiKey

--- a/Sources/AiSTKit/AnalyzerConfiguration.swift
+++ b/Sources/AiSTKit/AnalyzerConfiguration.swift
@@ -1,0 +1,71 @@
+//
+//  AnalyzerConfiguration.swift
+//  SyntaxKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the “Software”), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+/// Configuration for the SyntaxKit analyzer, assembled by the `skit analyze`
+/// subcommand from parsed command-line arguments and handed to
+/// `SyntaxKitAnalyzer`.
+public struct AnalyzerConfiguration: Sendable {
+  /// Folder containing `dsl.swift` and `expected.swift`.
+  public let inputFolderPath: String
+  /// Path to the existing SyntaxKit library sources.
+  public let syntaxKitPath: String
+  /// Where to write the updated library.
+  public let outputFolderPath: String
+  /// Claude API key.
+  public let apiKey: String
+  /// Claude model identifier.
+  public let model: String
+  /// Enables verbose progress output.
+  public let verbose: Bool
+
+  /// Creates an analyzer configuration.
+  ///
+  /// - Parameters:
+  ///   - inputFolderPath: Folder containing `dsl.swift` and `expected.swift`.
+  ///   - syntaxKitPath: Path to the existing SyntaxKit library sources.
+  ///   - outputFolderPath: Where to write the updated library.
+  ///   - apiKey: Claude API key.
+  ///   - model: Claude model identifier.
+  ///   - verbose: Enables verbose progress output.
+  public init(
+    inputFolderPath: String,
+    syntaxKitPath: String,
+    outputFolderPath: String,
+    apiKey: String,
+    model: String,
+    verbose: Bool
+  ) {
+    self.inputFolderPath = inputFolderPath
+    self.syntaxKitPath = syntaxKitPath
+    self.outputFolderPath = outputFolderPath
+    self.apiKey = apiKey
+    self.model = model
+    self.verbose = verbose
+  }
+}

--- a/Sources/AiSTKit/AnalyzerError.swift
+++ b/Sources/AiSTKit/AnalyzerError.swift
@@ -1,0 +1,49 @@
+//
+//  AnalyzerError.swift
+//  SyntaxKit
+//
+//  Created by Leo Dion.
+//  Copyright © 2026 BrightDigit.
+//
+//  Permission is hereby granted, free of charge, to any person
+//  obtaining a copy of this software and associated documentation
+//  files (the “Software”), to deal in the Software without
+//  restriction, including without limitation the rights to use,
+//  copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following
+//  conditions:
+//
+//  The above copyright notice and this permission notice shall be
+//  included in all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+//  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+//  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+//  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+//  OTHER DEALINGS IN THE SOFTWARE.
+//
+
+/// Errors thrown by the `skit analyze` pipeline. Each case carries a
+/// human-readable message; the subcommand decides how to present it.
+public enum AnalyzerError: Error {
+  /// Required command-line arguments were not provided.
+  case missingRequiredArguments(String)
+  /// No API key was provided via flag or the `ANTHROPIC_API_KEY`
+  /// environment variable.
+  case missingAPIKey(String)
+  /// The input or SyntaxKit path does not exist.
+  case invalidPath(String)
+  /// A required input file (`dsl.swift`, `expected.swift`) was not found
+  /// in the input folder.
+  case missingInputFile(String)
+  /// Generating the AST from the input sources failed.
+  case astGenerationError(String)
+  /// The Claude API call failed (network, authentication, rate limit, …).
+  case apiError(String)
+  /// Parsing the generated code out of Claude's response failed.
+  case codeGenerationError(String)
+}


### PR DESCRIPTION
Closes #110

## Summary
- Add `AnalyzerConfiguration` (`Sources/AiSTKit/AnalyzerConfiguration.swift`): a plain `public struct … : Sendable` with `inputFolderPath`, `syntaxKitPath`, `outputFolderPath`, `apiKey`, `model`, and `verbose`. Includes an explicit `public init` since the auto-generated memberwise init would be `internal` and the `skit analyze` subcommand (#111) constructs it from another module.
- Add `AnalyzerError` (`Sources/AiSTKit/AnalyzerError.swift`): `public enum … : Error` with all seven cases from the plan doc (`missingRequiredArguments`, `missingAPIKey`, `invalidPath`, `missingInputFile`, `astGenerationError`, `apiError`, `codeGenerationError`), each carrying a message string.

No configuration-framework dependency; one type per file per [skit-analyze-plan.md](Docs/skit-analyze-plan.md).

## Verification
- `swift build` passes
- Both files pass `swift-format lint` and `swiftlint --strict` with zero violations
- `./Scripts/lint.sh` reports only a pre-existing local Periphery failure ("index store path does not exist"), which reproduces on the clean tree and is skipped on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)